### PR TITLE
Install additional R packages in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 # install R packages
 RUN Rscript -e 'install.packages("vegan")'
+RUN Rscript -e 'install.packages("palmerpenguins")'
+RUN Rscript -e 'remotes::install_github("G-Thomson/Manu")'
+RUN Rscript -e 'remotes::install_github("viridis")'
+RUN Rscript -e 'remotes::install_github("ggbeeswarm")'
+RUN Rscript -e 'remotes::install_github("ggtext")'
 
 # copy the introduction to R source into the repo
 ARG INTROR_HASH=0729df3d1877356c120612586ca541cf8da17b0e


### PR DESCRIPTION
Added installation commands for additional R packages including 'palmerpenguins', 'Manu', 'viridis', 'ggbeeswarm', and 'ggtext'.